### PR TITLE
[AS7-6860] jboss-dmr APIs are unable to parse swidish characters

### DIFF
--- a/src/main/java/org/jboss/dmr/ModelNodeParser.java
+++ b/src/main/java/org/jboss/dmr/ModelNodeParser.java
@@ -139,7 +139,7 @@ class ModelNodeParser extends Parser {
                         case 'r': b.append('\r'); break;
                         case 'b': b.append('\b'); break;
                         case 'f': b.append('\f'); break;
-                        case 'u': b.append((char) Integer.parseInt(yyText.substring(i + 1, i + 5))); i+=4; break;
+                        case 'u': b.append((char) Integer.parseInt(yyText.substring(i + 1, i + 5), 16)); i+=4; break;
                         default: b.appendCodePoint(ch); break;
                     }
                     break;


### PR DESCRIPTION
JBossAS7.2  dmr-api's are unable to parse swidish characters .
Example:
========= Run the following CLI command which will fail:
[standalone@localhost:9999 /] /core-service=management/ldap-connection=ldap_connection/:add(search-credential=jboss@123,url=ldap://xx.xx.xxx.xx:389,search-dn="ou=\u00E5\u00E5
u00E5,dc=example,dc=com")

Ideally it should have generated the following configuration inside the server profile (standalone.xml)

&lt;outbound-connections&gt;
&lt;ldap name="ldap_connection" url="ldap://xx.xx.xxx.xx:389" search-dn="ou=ååå,dc=example,dc=com" search-credential="jboss@123"/&gt;
&lt;/outbound-connections&gt;
