### PR TITLE
[DMR-40] Add Automatic-Module-Name so that DMR is usable on the module path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 
     <properties>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
+        <module.name>org.jboss.dmr</module.name>
     </properties>
 
     <dependencies>
@@ -133,6 +134,16 @@
                     <links>
                         <link>http://java.sun.com/javase/6/docs/api/</link>
                     </links>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This simple change enables JBoss DMR to be used on the module path.

I tried to choose the name following the module-naming guidelines (i.e. reverse domain name).