### PR TITLE
[DMR-45] Enhance value expression resolution to also look at environment variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,19 +54,45 @@
         <version.org.wildfly.checkstyle-config>1.0.6.Final</version.org.wildfly.checkstyle-config>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
         <module.name>org.jboss.dmr</module.name>
+        <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.9.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.junit>4.13.1</version.junit>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${version.org.jboss.logging.jboss-logging}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!--
+                This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                projects that depend on this project.
+            -->
+            <scope>provided</scope>
+            <optional>true</optional>
+            <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
-            <version>2.0.9.Final</version>
+            <version>${version.org.jboss.logmanager.jboss-logmanager}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,9 @@
                 <version>${version.surefire.plugin}</version>
                 <configuration>
                     <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <environmentVariables>
+                        <TEST_ENVIRONMENT_VARIABLE>Hello world</TEST_ENVIRONMENT_VARIABLE>
+                    </environmentVariables>
                     <systemProperties>
                         <property>
                             <name>java.util.logging.manager</name>

--- a/src/main/java/org/jboss/dmr/ValueExpressionResolver.java
+++ b/src/main/java/org/jboss/dmr/ValueExpressionResolver.java
@@ -24,6 +24,8 @@ package org.jboss.dmr;
 
 import java.io.File;
 
+import org.jboss.dmr._private.JBossDmrLogger;
+
 /**
  * A resolver for value expressions.
  *
@@ -201,6 +203,9 @@ public class ValueExpressionResolver {
             // See if an env var is defined
             String envVar = replaceNonAlphanumericByUnderscoresAndMakeUpperCase(name);
             val = System.getenv(envVar);
+            if (val != null) {
+                JBossDmrLogger.LOGGER.debugf("Found environment variable '%s' to resolve the expression name '%s'", envVar, name);
+            }
         }
 
         if (val == null && name.startsWith("env."))

--- a/src/main/java/org/jboss/dmr/ValueExpressionResolver.java
+++ b/src/main/java/org/jboss/dmr/ValueExpressionResolver.java
@@ -194,12 +194,36 @@ public class ValueExpressionResolver {
         } else if (":".equals(name)) {
             return File.pathSeparator;
         }
-        // First check for system property, then env variable
+        // First check for system property, then env variables
         String val = System.getProperty(name);
+
+        if (val == null) {
+            // See if an env var is defined
+            String envVar = replaceNonAlphanumericByUnderscoresAndMakeUpperCase(name);
+            val = System.getenv(envVar);
+        }
+
         if (val == null && name.startsWith("env."))
             val = System.getenv(name.substring(4));
 
         return val;
+    }
+
+
+    private String replaceNonAlphanumericByUnderscoresAndMakeUpperCase(final String name) {
+        int length = name.length();
+        StringBuilder sb = new StringBuilder();
+        int c;
+        for (int i = 0; i < length; i += Character.charCount(c)) {
+            c = Character.toUpperCase(name.codePointAt(i));
+            if ('A' <= c && c <= 'Z' ||
+                    '0' <= c && c <= '9') {
+                sb.appendCodePoint(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        return sb.toString();
     }
 
     private static final int INITIAL = 0;

--- a/src/main/java/org/jboss/dmr/_private/JBossDmrLogger.java
+++ b/src/main/java/org/jboss/dmr/_private/JBossDmrLogger.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.dmr._private;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@MessageLogger(projectCode = "JBDMR", length = 4)
+public interface JBossDmrLogger extends BasicLogger {
+    JBossDmrLogger LOGGER = Logger.getMessageLogger(JBossDmrLogger.class, "org.jboss.dmr");
+}

--- a/src/test/java/org/jboss/dmr/test/EnvironmentVariableResolutionTest.java
+++ b/src/test/java/org/jboss/dmr/test/EnvironmentVariableResolutionTest.java
@@ -1,0 +1,46 @@
+package org.jboss.dmr.test;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ValueExpression;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class EnvironmentVariableResolutionTest {
+
+    private ValueExpression expr = new ValueExpression("${test.environment-variable}");
+
+    @Test
+    public void testEnviromentVariable() throws Exception {
+        ModelNode node = new ModelNode(expr);
+        ModelNode result = node.resolve();
+        Assert.assertEquals("Hello world", result.asString());
+    }
+
+    @Test
+    public void testEnviromentVariableOverriddenBySystemProperty() throws Exception {
+        try {
+            System.setProperty("test.environment-variable", "Hola mundo");
+            ModelNode node = new ModelNode(expr);
+            ModelNode result = node.resolve();
+            Assert.assertEquals("Hola mundo", result.asString());
+        } finally {
+            System.clearProperty("test.environment-variable");
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testNoEnvironmentVariableOrSystemProperty() throws Exception {
+        ModelNode node = new ModelNode(new ValueExpression("${test.environment-variable.non-existent}"));
+        ModelNode result = node.resolve();
+    }
+
+    @Test
+    public void testLegacyEnviromentVariable() throws Exception {
+        ModelNode node = new ModelNode(new ValueExpression("${env.TEST_ENVIRONMENT_VARIABLE}"));
+        ModelNode result = node.resolve();
+        Assert.assertEquals("Hello world", result.asString());
+    }
+}


### PR DESCRIPTION
This updates to use parts of the MicroProfile Config strategy to resolve expressions from environment variables.

The order of precedence is:
* Try the system property (e.g. `my-property`)
* Look for an environment variable with the name converted to upper case, replacing non-alphanumeric characters with underscores (e.g. `MY_PROPERTY`)
* If the expression starts with `env.` we look for an environment variable with the prefix stripped off (e.g. for `env.MY_PROPERTY` we look for the environment variable `MY_PROPERTY`)

https://issues.redhat.com/browse/DMR-45